### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 description = "ZeroNet address"
 documentation = "http://www.github.com/Anshorei/zeronet_address"
 readme = "README.md"
-homepage = "http://www.github.com/Anshorei/zeronet_address"
-repository = "http://www.github.com/Anshorei/zeronet_address"
+homepage = "https://www.github.com/Anshorei/zeronet_address"
+repository = "https://www.github.com/Anshorei/zeronet_address"
 license = "WTFPL"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97